### PR TITLE
Update for -Wformat-security

### DIFF
--- a/genesis/src/sim/sim_method.c
+++ b/genesis/src/sim/sim_method.c
@@ -205,7 +205,7 @@ int check_method(method)
 		}
 
 	if (valid && IsSilent() < 1) {
-	    printf(methodstr);
+	    printf("%s", methodstr);
 	}
 
 	return(valid);

--- a/genesis/src/tools/lump_p.c
+++ b/genesis/src/tools/lump_p.c
@@ -146,7 +146,7 @@ void do_lump_cell(argc,argv)
 		case '\n' :
 		case '\r' :
 		case '\0' :
-		    fprintf(fn,line);
+		    fprintf(fn,"%s",line);
 		    continue;
 		case '/' :
 		    if (line[1] == '/') {


### PR DESCRIPTION
https://fedoraproject.org/wiki/Format-Security-FAQ

A few minor required to get genesis to build with -Wformat-security enabled in GCC.